### PR TITLE
MNEMONIC-60:Apply Transaction, Retrievable interfaces to class VolatileMemAllocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ dependency-reduced-pom.xml
 service-dist/
 .*.html
 testlog/
+.DS_Store
+

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/VolatileMemAllocator.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/VolatileMemAllocator.java
@@ -29,11 +29,12 @@ import org.flowcomputing.commons.resgc.ResReclaim;
  * 
  *
  */
-public class VolatileMemAllocator extends CommonAllocator<VolatileMemAllocator> {
+public class VolatileMemAllocator extends RestorableAllocator<VolatileMemAllocator> {
 
   private boolean m_activegc = true;
   private long m_gctimeout = 100;
   private long m_nid = -1;
+  private long[][] m_ttable;
   private VolatileMemoryAllocatorService m_vmasvc = null;
 
   /**
@@ -273,6 +274,231 @@ public class VolatileMemAllocator extends CommonAllocator<VolatileMemAllocator> 
       }
     }
     return ret;
+  }
+
+  /**
+   * retrieve a memory buffer from its backed memory allocator.
+   * 
+   * @param phandler
+   *          specify the handler of memory buffer to retrieve
+   *
+   * @param autoreclaim
+   *          specify whether this retrieved memory buffer can be reclaimed
+   *          automatically or not
+   * 
+   * @return a holder contains the retrieved memory buffer
+   */
+  @Override
+  public MemBufferHolder<VolatileMemAllocator> retrieveBuffer(long phandler, boolean autoreclaim) {
+    MemBufferHolder<VolatileMemAllocator> ret = null;
+    ByteBuffer bb = m_vmasvc.retrieveByteBuffer(m_nid, getEffectiveAddress(phandler));
+    if (null != bb) {
+      ret = new MemBufferHolder<VolatileMemAllocator>(this, bb);
+      if (autoreclaim) {
+        m_bufcollector.register(ret);
+      }
+    }
+    return ret;
+  }
+
+  /**
+   * retrieve a memory chunk from its backed memory allocator.
+   * 
+   * @param phandler
+   *          specify the handler of memory chunk to retrieve
+   *
+   * @param autoreclaim
+   *          specify whether this retrieved memory chunk can be reclaimed
+   *          automatically or not
+   * 
+   * @return a holder contains the retrieved memory chunk
+   */
+  @Override
+  public MemChunkHolder<VolatileMemAllocator> retrieveChunk(long phandler, boolean autoreclaim) {
+    MemChunkHolder<VolatileMemAllocator> ret = null;
+    long eaddr = getEffectiveAddress(phandler);
+    long sz = m_vmasvc.retrieveSize(m_nid, eaddr);
+    if (sz > 0L) {
+      ret = new MemChunkHolder<VolatileMemAllocator>(this, eaddr, sz);
+      if (autoreclaim) {
+        m_chunkcollector.register(ret);
+      }
+    }
+    return ret;
+  }
+
+  /**
+   * get the handler from a memory buffer holder.
+   * 
+   * @param mbuf
+   *          specify the memory buffer holder
+   *
+   * @return a handler that could be used to retrieve its memory buffer
+   */
+  @Override
+  public long getBufferHandler(MemBufferHolder<VolatileMemAllocator> mbuf) {
+    return getPortableAddress(m_vmasvc.getByteBufferHandler(m_nid, mbuf.get()));
+  }
+
+  /**
+   * get the handler from a memory chunk holder.
+   * 
+   * @param mchunk
+   *          specify the memory chunk holder
+   *
+   * @return a handler that could be used to retrieve its memory chunk
+   */
+  @Override
+  public long getChunkHandler(MemChunkHolder<VolatileMemAllocator> mchunk) {
+    return getPortableAddress(mchunk.get());
+  }
+
+  /**
+   * determine whether this allocator supports to store non-volatile handler or
+   * not. (it is a placeholder)
+   *
+   * @return true if there is
+   */
+  @Override
+  public boolean hasDurableHandlerStore() {
+    return true;
+  }
+
+  /**
+   * determine whether the allocator supports transaction feature or not
+   *
+   * @return true if supported
+   */
+  @Override
+  public boolean supportTransaction() {
+    return false;
+  }
+
+  /**
+   * start a application level transaction on this allocator. (it is a place
+   * holder)
+   *
+   */
+  @Override
+  public void beginTransaction() {
+    throw new UnsupportedOperationException("Transaction Unsupported.");
+  }
+
+  /**
+   * end a application level transaction on this allocator. (it is a place
+   * holder)
+   *
+   */
+  @Override
+  public void endTransaction() {
+    throw new UnsupportedOperationException("Transaction Unsupported.");
+  }
+
+  /**
+   * determine whether the allocator does atomic operations on memory pool
+   *
+   * @return true if it does
+   *
+   */
+  @Override
+  public boolean isAtomicOperation() {
+    return false;
+  }
+
+  /**
+   * set a handler on key.
+   * 
+   * @param key
+   *          the key to set its value
+   * 
+   * @param handler
+   *          the handler
+   */
+  @Override
+  public void setHandler(long key, long handler) {
+    m_vmasvc.setHandler(m_nid, key, handler);
+  }
+
+  /**
+   * get a handler value.
+   * 
+   * @param key
+   *          the key to set its value
+   * 
+   * @return the value of handler
+   */
+  @Override
+  public long getHandler(long key) {
+    return m_vmasvc.getHandler(m_nid, key);
+  }
+
+  /**
+   * return the capacity of non-volatile handler store.
+   * 
+   * @return the capacity of handler store
+   * 
+   */
+  public long handlerCapacity() {
+    return m_vmasvc.handlerCapacity(m_nid);
+  }
+
+  /**
+   * translate the portable address
+   *
+   * @param addr
+   *          the address to be translated
+   *
+   * @return the portable address
+   */
+  @Override
+  public long getPortableAddress(long addr) {
+    int i;
+    for (i = 0; i < m_ttable.length; ++i) {
+      if (addr >= m_ttable[i][2] && addr < m_ttable[i][1] + m_ttable[i][2]) {
+        return addr - m_ttable[i][2];
+      }
+    }
+    throw new AddressTranslateError("Portable Address Translate Error");
+  }
+
+  /**
+   * translate the effective address
+   *
+   * @param addr
+   *          the address to be translated
+   *
+   * @return the effective address
+   */
+  @Override
+  public long getEffectiveAddress(long addr) {
+    int i;
+    for (i = 0; i < m_ttable.length; ++i) {
+      if (addr >= m_ttable[i][0] && addr < m_ttable[i][1]) {
+        return addr + m_ttable[i][2];
+      }
+    }
+    throw new AddressTranslateError("Effective Address Translate Error");
+  }
+
+  /**
+   * get the address translate table
+   *
+   * @return the translate table
+   */
+  @Override
+  public long[][] getTranslateTable() {
+    return m_ttable;
+  }
+
+  /**
+   * set address translate table
+   *
+   * @param tbl
+   *         specify a translate table
+   */
+  @Override
+  public void setTranslateTable(long[][] tbl) {
+    m_ttable = tbl;
   }
 
 }

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/service/allocatorservice/VolatileMemoryAllocatorService.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/service/allocatorservice/VolatileMemoryAllocatorService.java
@@ -21,6 +21,96 @@ import java.nio.ByteBuffer;
 
 public interface VolatileMemoryAllocatorService {
 
+
+  /**
+   * retrieve a bytebuffer from its handler
+   *
+   * @param id
+   *          the identifier of backed memory pool
+   * 
+   * @param handler
+   *          the handler of a nonvolatile bytebuffer
+   *
+   * @return the nonvolatile bytebuffer
+   *
+   */
+  ByteBuffer retrieveByteBuffer(long id, long handler);
+
+  /**
+   * retrieve the size of a nonvolatile memory object
+   *
+   * @param id
+   *          the identifier of backed memory pool
+   * 
+   * @param handler
+   *          the handler of a nonvolatile object
+   *
+   * @return the size of nonvolatile object
+   *
+   */
+  long retrieveSize(long id, long handler);
+
+  /**
+   * get the handler of a nonvolatile bytebuffer
+   *
+   * @param id
+   *          the identifier of backed memory pool
+   * 
+   * @param buf
+   *          the nonvolatile bytebuffer
+   *
+   * @return the handler of this specified nonvolatile bytebuffer
+   *
+   */
+  long getByteBufferHandler(long id, ByteBuffer buf);
+
+  /**
+   * set a handler to a key.
+   * 
+   * @param id
+   *          the identifier of backed memory pool
+   * 
+   * @param key
+   *          the key to set this handler
+   * 
+   * @param handler
+   *          the handler
+   */
+  void setHandler(long id, long key, long handler);
+
+  /**
+   * get a handler from specified key.
+   * 
+   * @param id
+   *          the identifier of backed memory pool
+   * 
+   * @param key
+   *          the key to get its handler
+   * 
+   * @return the handler of the specified key
+   */
+  long getHandler(long id, long key);
+
+  /**
+   * return the number of available keys to use.
+   * 
+   * @param id
+   *          the identifier of backed memory pool
+   * 
+   * @return the number of keys
+   */
+  long handlerCapacity(long id);
+
+  /**
+   * return the base address of this persistent memory pool.
+   * 
+   * @param id
+   *          the identifier of backed memory pool
+   * 
+   * @return the base address of this pmem pool
+   */
+  long getBaseAddress(long id);
+
   /**
    * Provide the service identifier for this allocator
    *

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/java/org/apache/mnemonic/service/allocatorservice/internal/VMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/java/org/apache/mnemonic/service/allocatorservice/internal/VMemServiceImpl.java
@@ -93,6 +93,41 @@ public class VMemServiceImpl implements VolatileMemoryAllocatorService {
     ndestroyByteBuffer(id, bytebuf);
   }
 
+  @Override
+  public ByteBuffer retrieveByteBuffer(long id, long handler) {
+    return nretrieveByteBuffer(id, handler);
+  }
+
+  @Override
+  public long retrieveSize(long id, long handler) {
+    return nretrieveSize(id, handler);
+  }
+
+  @Override
+  public long getByteBufferHandler(long id, ByteBuffer buf) {
+    return ngetByteBufferHandler(id, buf);
+  }
+
+  @Override
+  public void setHandler(long id, long key, long handler) {
+    nsetHandler(id, key, handler);
+  }
+
+  @Override
+  public long getHandler(long id, long key) {
+    return ngetHandler(id, key);
+  }
+
+  @Override
+  public long handlerCapacity(long id) {
+    return nhandlerCapacity(id);
+  }
+
+  @Override
+  public long getBaseAddress(long id) {
+    return ngetBaseAddress(id);
+  }
+
   protected native long ninit(long capacity, String uri, boolean isnew);
 
   protected native void nclose(long id);
@@ -112,5 +147,19 @@ public class VMemServiceImpl implements VolatileMemoryAllocatorService {
   protected native ByteBuffer nresizeByteBuffer(long id, ByteBuffer bytebuf, long size);
 
   protected native void ndestroyByteBuffer(long id, ByteBuffer bytebuf);
+
+  protected native ByteBuffer nretrieveByteBuffer(long id, long handler);
+
+  protected native long nretrieveSize(long id, long handler);
+
+  protected native long ngetByteBufferHandler(long id, ByteBuffer buf);
+
+  protected native void nsetHandler(long id, long key, long handler);
+
+  protected native long ngetHandler(long id, long key);
+
+  protected native long nhandlerCapacity(long id);
+
+  protected native long ngetBaseAddress(long id);
 
 }

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl.c
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl.c
@@ -100,6 +100,38 @@ jobject JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemS
 }
 
 JNIEXPORT
+jobject JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_nretrieveByteBuffer(
+    JNIEnv *env, jobject this, jlong id, jlong e_addr, jlong size) {
+  jobject ret = NULL;
+  void* p = addr_from_java(e_addr);
+  ret = NULL != p ? (*env)->NewDirectByteBuffer(env, p, size) : NULL;
+  return ret;
+}
+
+JNIEXPORT
+jlong JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_nretrieveSize(JNIEnv *env,
+    jobject this, jlong id, jlong e_addr, jlong size) {
+  jlong ret = 0L;
+  void* p = addr_from_java(e_addr);
+  ret = NULL != p ? (*env)->NewDirectByteBuffer(env, p, size) : NULL;
+  return ret;
+}
+
+JNIEXPORT
+jlong JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_ngetByteBufferHandler(
+    JNIEnv *env, jobject this, jlong id, jobject bytebuf) {
+//  fprintf(stderr, "ngetByteBufferAddress Get Called %X, %X\n", env, bytebuf);
+  jlong ret = 0L;
+  if (NULL != bytebuf) {
+    void* nativebuf = (*env)->GetDirectBufferAddress(env, bytebuf);
+//      fprintf(stderr, "ngetByteBufferAddress Get Native address %X\n", nativebuf);
+    ret = addr_to_java(nativebuf);
+  }
+//    fprintf(stderr, "ngetByteBufferAddress returned address %016lx\n", ret);
+  return ret;
+}
+
+JNIEXPORT
 jobject JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_nresizeByteBuffer(
     JNIEnv *env, jobject this, jlong id, jobject bytebuf, jlong size) {
   pthread_rwlock_rdlock(&g_vmem_rwlock);
@@ -131,6 +163,37 @@ void JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServ
   }
   pthread_mutex_unlock(g_vmem_mutex_ptr + id);
   pthread_rwlock_unlock(&g_vmem_rwlock);
+}
+
+
+JNIEXPORT
+void JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_nsetHandler(
+    JNIEnv *env, jobject this, jlong id, jlong key, jlong value)
+{
+  throw(env, "setkey()/getkey() temporarily not suppoted");
+}
+
+JNIEXPORT
+jlong JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_ngetHandler(JNIEnv *env,
+    jobject this, jlong id, jlong key) {
+  throw(env, "setkey()/getkey() temporarily not suppoted");
+}
+
+JNIEXPORT
+jlong JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_nhandlerCapacity(
+    JNIEnv *env, jobject this) {
+  throw(env, "setkey()/getkey() temporarily not suppoted");
+}
+
+
+JNIEXPORT
+jlong JNICALL Java_org_apache_mnemonic_service_allocatorservice_internal_VMemServiceImpl_ngetBaseAddress(JNIEnv *env,
+    jobject this, jlong id) {
+  pthread_rwlock_rdlock(&g_vmem_rwlock);
+  void *md = *(g_vmp_ptr + id);
+  jlong ret = (long) b_addr(md);
+  pthread_rwlock_unlock(&g_vmem_rwlock);
+  return ret;
 }
 
 JNIEXPORT


### PR DESCRIPTION
> The current implementation of class VolatileMemAllocator does not support retrieval operations so it is not possible to temporarily forget cached durable objects efficiently like class NonVolatileMemAllocator does, logically, volatile memory should be retrievable for durable object graphs in a applications/frameworks run-time session.
> In addition, durable native computing must based on retrievable interface, therefore the VolatileMemAllocator should implement retrievable interface to support forgettable object graphs and durable native computing.
