### PR TITLE
MNEMONIC-114: nvml-vmem-service compilation warnings

### DIFF
--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl.c
@@ -114,7 +114,7 @@ jlong JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServic
     jobject this, jlong id, jlong addr, jlong size) {
   jlong ret = 0L;
   void* p = addr_from_java(addr);
-  ret = NULL != p ? (*env)->NewDirectByteBuffer(env, p, size) : NULL;
+  ret = NULL != p ? (*env)->NewDirectByteBuffer(env, p, size) : 0L;
   return ret;
 }
 
@@ -178,12 +178,14 @@ JNIEXPORT
 jlong JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_ngetHandler(JNIEnv *env,
     jobject this, jlong id, jlong key) {
   throw(env, "setkey()/getkey() temporarily not suppoted");
+  return 0;
 }
 
 JNIEXPORT
 jlong JNICALL Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_nhandlerCapacity(
     JNIEnv *env, jobject this) {
   throw(env, "setkey()/getkey() temporarily not suppoted");
+  return 0;
 }
 
 


### PR DESCRIPTION
There is still a warning for "Java_org_apache_mnemonic_service_memoryservice_internal_VMemServiceImpl_nretrieveSize" when I change null to 0L.  Will update the NewDirectByteBuffer to GetDirectBufferAddress.