### PR TITLE
MNEMONIC-204: Fix issues with the pmalloc service on MacOS

### DIFF
--- a/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/native/CMakeLists.txt
@@ -18,6 +18,8 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(pmallocallocator)
 
+include_directories(/usr/local/include)
+
 configure_file (
   "${PROJECT_SOURCE_DIR}/config.h.in"
     "${PROJECT_BINARY_DIR}/config.h"


### PR DESCRIPTION
appended  /usr/local onto the current list of directories in CMakeList