### PR TITLE
MNEMONIC-105: Adding Testcases for durable buffers and chunks

### DIFF
--- a/mnemonic-collections/pom.xml
+++ b/mnemonic-collections/pom.xml
@@ -39,6 +39,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.flowcomputing.commons</groupId>
       <artifactId>commons-primitives</artifactId>
     </dependency>


### PR DESCRIPTION
Added missing testcases for having durable buffer/chunks as HashMap values