### PR TITLE
MNEMONIC-233: Restore the resources before destroy of Generic Field

### DIFF
--- a/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
@@ -362,17 +362,19 @@ public class GenericField<A extends RestorableAllocator<A>, E> implements Durabl
    */
   @Override
   public void destroy() throws RetrieveDurableEntityError {
-    if (null != m_field) {
-      m_field.destroy();
-    }
-    if (null != m_strfield) {
-      m_strfield.destroy();
-    }
-    if (null != m_chunkfield) {
-      m_chunkfield.destroy();
-    }
-    if (null != m_bufferfield) {
-      m_bufferfield.destroy();
+    if (null != get()) {
+      if (null != m_field) {
+        m_field.destroy();
+      }
+      if (null != m_strfield) {
+        m_strfield.destroy();
+      }
+      if (null != m_chunkfield) {
+        m_chunkfield.destroy();
+      }
+      if (null != m_bufferfield) {
+        m_bufferfield.destroy();
+      }
     }
   }
 


### PR DESCRIPTION
There will be memory leaks if resources are not restored during destroy of a generic field.