### PR TITLE
MNEMONIC-274 Add another Dockerfile for Ubuntu system

### DIFF
--- a/docker-ubuntu/Dockerfile
+++ b/docker-ubuntu/Dockerfile
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM ubuntu:16.04
+MAINTAINER Yanhui Zhao (yanhui.zhao@outlook.com)
+
+#set up your proxy below, please refer to readme in the Docker folder
+ARG proxy_host=""
+ARG proxy_port=""
+ENV http_proxy ${proxy_host:+"http://${proxy_host}:${proxy_port}"}
+ENV https_proxy ${http_proxy}
+ENV HTTP_PROXY ${http_proxy}
+ENV HTTPS_PROXY ${http_proxy}
+
+RUN echo The proxy set : ${http_proxy}
+
+RUN apt-get -y update && \
+    apt-get install -y default-jdk cmake check git maven pkg-config autoconf man build-essential gcc g++ uuid-dev pandoc devscripts flex doxygen
+
+RUN apt-get clean
+    
+ENV M2_HOME /usr/share/maven
+ENV M2 $M2_HOME/bin
+ENV PATH $M2:$PATH
+ENV JAVA_HOME /usr/lib/jvm/default-java
+ENV PATH $JAVA_HOME/bin:$PATH
+
+RUN mkdir -p /ws
+RUN cd /ws && git clone https://github.com/NonVolatileComputing/pmalloc.git && \
+    cd pmalloc && mkdir build && cd build && cmake .. && make && make install 
+    
+RUN cd /ws && git clone https://github.com/pmem/nvml.git && \
+    cd nvml && git checkout 630862e82f && make && make install
+
+RUN echo export MAVEN_OPTS="\" $([[ \"x\" != \"x${proxy_host}\" ]] && echo -DproxySet=\\\"true\\\" -DproxyHost=${proxy_host} -DproxyPort=${proxy_port}) \"" \
+    > /etc/profile.d/mvn.sh && chmod +x /etc/profile.d/mvn.sh
+    
+RUN /bin/bash -c "source /etc/profile.d/mvn.sh"
+    
+RUN cd /ws && git clone https://github.com/apache/incubator-mnemonic.git && \
+    cd incubator-mnemonic && mvn clean package install
+
+ENV MNEMONIC_HOME /ws/incubator-mnemonic
+
+#RUN cd /ws/incubator-mnemonic && build-tools/runall.sh -y
+
+WORKDIR /ws
+
+CMD ["bash"]
+

--- a/docker-ubuntu/README.md
+++ b/docker-ubuntu/README.md
@@ -1,0 +1,75 @@
+<img src="http://nonvolatilecomputing.github.io/Mnemonic/images/mnemonic_logo.png" width=200 />
+
+================================ 
+
+This is the "Dockerfile" that will automatically build the environment of this project under ubuntu. 
+
+--------------
+### Features:
+
+*What does this Dockerfile do?* 
+
+- 1. Build from ubuntu 16.04.
+- 2. Default is not using proxy. Please see instruction below to set up http/https proxy.
+- 3. Install dependency packages.
+- 4. Set up environment variables of paths.
+- 5. Create /ws folder.
+- 6. Install pmalloc in /ws
+- 7. Install nvml in /ws.
+- 8. Set up maven proxy mvn.sh.
+- 9. Clone mnemonic code then build/install.  
+- 10. Go to /ws fold and start bash.  
+
+#### How to set up proxy? 
+
+Set the argument "http_proxy" for the docker option "--build-arg" as follows
+```bash
+  $ docker build -t NAME[:TAG] --build-arg proxy_host="<proxy_host>" proxy_port="<proxy_port>" .
+```
+
+For old version docker v1.10 below, Please replace ARG with ENV and set its value as proxy strings in Dockerfile instead
+
+### How to build the docker image from Dockerfile in host OS?
+Build from git repository
+
+```bash
+  $ docker build -t NAME[:TAG] https://github.com/apache/incubator-mnemonic.git#:docker-ubuntu
+```
+
+-- OR --
+
+In the folder of Dockerfile, run: 
+
+```bash
+  $ docker build -t NAME[:TAG] .
+```
+
+* More detials please refer to [Docker build reference](https://docs.docker.com/engine/reference/commandline/build/)
+
+#### Optional: After build, push image to dockerhub: 
+
+```bash
+  $ docker login [OPTIONS] [SERVER]  
+  $ docker push [OPTIONS] NAME[:TAG]
+```
+
+* More detials please refer to [Docker login reference](https://docs.docker.com/engine/reference/commandline/login/)
+ and [Docker push reference](https://docs.docker.com/engine/reference/commandline/push/)
+
+### How to run image after build
+
+Run image:
+
+```bash
+  $ docker run --name CONTAINER_NAME -it NAME[:TAG]
+```
+
+### Sharing host project folder to Dock container for IDEs e.g. Eclipse, Intellij IDEA
+
+```bash
+  $ docker run -v <hostdir>/incubator-mnemonic:/ws/incubator-mnemonic -it NAME[:TAG]
+```
+Note: this command will override the container's project folder, you can use another name to avoid it.
+
+ * More details please refer to [Docker run reference](https://docs.docker.com/engine/reference/run/)
+


### PR DESCRIPTION
The existed Dockerfile has described how to setup Mnemonic development environment for CentOS only, so we need another one for Ubuntu, because the Ubuntu also is one of most popular server system.