### PR TITLE
MNEMONIC-280 Add overload methods to handle optional paramters

### DIFF
--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashMapImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashMapImpl.java
@@ -27,6 +27,7 @@ import org.apache.mnemonic.RestorableAllocator;
 import org.apache.mnemonic.RestoreDurableEntityError;
 import org.apache.mnemonic.RetrieveDurableEntityError;
 import org.apache.mnemonic.Utils;
+import org.apache.mnemonic.ParameterHolder;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.ArrayUtils;
@@ -478,11 +479,24 @@ public class DurableHashMapImpl<A extends RestorableAllocator<A>, K, V>
         return MapEntryFactory.restore(allocator, dpt.getRight(), dpt.getLeft(), phandler, autoreclaim);
           }
       @Override
+      public <A extends RestorableAllocator<A>> MapEntry<K, V> restore(ParameterHolder<A> ph) {
+          Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+              ph.getEntityFactoryProxies(), 1);
+        return MapEntryFactory.restore(ph.getAllocator(),
+              dpt.getRight(), dpt.getLeft(), ph.getHandler(), ph.getAutoReclaim());
+          }
+      @Override
       public <A extends RestorableAllocator<A>> MapEntry<K, V> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
           Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(gfields, factoryproxys, 1);
         return MapEntryFactory.create(allocator, dpt.getRight(), dpt.getLeft(), autoreclaim);
+          }
+      @Override
+      public <A extends RestorableAllocator<A>> MapEntry<K, V> create(ParameterHolder<A> ph) {
+          Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+              ph.getEntityFactoryProxies(), 1);
+        return MapEntryFactory.create(ph.getAllocator(), dpt.getRight(), dpt.getLeft(), ph.getAutoReclaim());
           }
     }
     };

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableArrayNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableArrayNGTest.java
@@ -35,6 +35,7 @@ import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.Durable;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Reclaim;
+import org.apache.mnemonic.ParameterHolder;
 import org.apache.commons.lang3.RandomUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -308,12 +309,23 @@ public class DurableArrayNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
       }
-    } };
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
+      } 
+    }
+    };
 
     Person<Long> person =  (Person<Long>) efproxies[0].create(m_act, null, null, false);
     person.setName("Alice", false);
@@ -355,11 +367,25 @@ public class DurableArrayNGTest {
         return DurableSinglyLinkedListFactory.restore(allocator, dpt.getRight(), dpt.getLeft(), phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+            ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.restore(ph.getAllocator(),
+            dpt.getRight(), dpt.getLeft(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Durable create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(gfields, factoryproxys, 1);
         return DurableSinglyLinkedListFactory.create(allocator, dpt.getRight(), dpt.getLeft(), autoreclaim);
+      }
+      @Override     
+      public <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+            ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.create(ph.getAllocator(),
+            dpt.getRight(), dpt.getLeft(), ph.getAutoReclaim());
       }
     }
     };
@@ -388,10 +414,20 @@ public class DurableArrayNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     }
     };
@@ -420,12 +456,26 @@ public class DurableArrayNGTest {
         return DurableHashMapFactory.restore(allocator, dpt.getRight(), dpt.getLeft(), phandler, autoreclaim);
           }
       @Override
+      public <A extends RestorableAllocator<A>> DurableHashMap<String, Person<Long>> restore(ParameterHolder<A> ph) {
+          Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+              ph.getEntityFactoryProxies(), 1);
+        return DurableHashMapFactory.restore(ph.getAllocator(),
+              dpt.getRight(), dpt.getLeft(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> DurableHashMap<String, Person<Long>> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
           Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(gfields, factoryproxys, 1);
         return DurableHashMapFactory.create(allocator, dpt.getRight(), dpt.getLeft(), 10, autoreclaim);
           }
+      @Override
+      public <A extends RestorableAllocator<A>> DurableHashMap<String, Person<Long>> create(ParameterHolder<A> ph) {
+          Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+              ph.getEntityFactoryProxies(), 1);
+        return DurableHashMapFactory.create(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), 10, ph.getAutoReclaim());
+      }
     }
     };
     arrayproxies = ArrayUtils.addAll(arrayproxies, efproxies);

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashMapNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashMapNGTest.java
@@ -33,6 +33,7 @@ import org.apache.mnemonic.DurableBuffer;
 import org.apache.mnemonic.DurableChunk;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.Durable;
+import org.apache.mnemonic.ParameterHolder;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.RandomUtils;
 import org.testng.annotations.AfterClass;
@@ -202,10 +203,20 @@ public class DurableHashMapNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
     
@@ -257,10 +268,20 @@ public class DurableHashMapNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
     
@@ -304,10 +325,20 @@ public class DurableHashMapNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     }, new EntityFactoryProxy() {
       @Override
@@ -317,10 +348,20 @@ public class DurableHashMapNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
 
@@ -355,10 +396,20 @@ public class DurableHashMapNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
     DurableType mapgtypes[] = {DurableType.STRING, DurableType.DURABLE, DurableType.STRING, DurableType.DURABLE};
@@ -371,11 +422,25 @@ public class DurableHashMapNGTest {
         return DurableHashMapFactory.restore(allocator, dpt.getRight(), dpt.getLeft(), phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 2);
+        return DurableHashMapFactory.restore(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Durable create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(gfields, factoryproxys, 2);
         return DurableHashMapFactory.create(allocator, dpt.getRight(), dpt.getLeft(), mInitialCapacity, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 2);
+        return DurableHashMapFactory.create(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), mInitialCapacity, ph.getAutoReclaim());
       }
     }, null, new EntityFactoryProxy() {
       @Override
@@ -385,10 +450,20 @@ public class DurableHashMapNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
     

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
@@ -31,6 +31,7 @@ import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.DurableType;
+import org.apache.mnemonic.ParameterHolder;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -117,10 +118,20 @@ public class DurableSinglyLinkedListNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
 
@@ -154,10 +165,20 @@ public class DurableSinglyLinkedListNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
 
@@ -224,11 +245,25 @@ public class DurableSinglyLinkedListNGTest {
         return DurableSinglyLinkedListFactory.restore(allocator, dpt.getRight(), dpt.getLeft(), phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.restore(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Durable create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(gfields, factoryproxys, 1);
         return DurableSinglyLinkedListFactory.create(allocator, dpt.getRight(), dpt.getLeft(), autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.create(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), ph.getAutoReclaim());
       }
     } };
 

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableTreeNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableTreeNGTest.java
@@ -29,6 +29,7 @@ import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.Reclaim;
 //import org.apache.mnemonic.Durable;
+import org.apache.mnemonic.ParameterHolder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -194,10 +195,20 @@ public class DurableTreeNGTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Person<Long> create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
 

--- a/mnemonic-computing-services/mnemonic-utilities-service/src/test/java/org/apache/mnemonic/service/computingservice/DurableSinglyLinkedListNGPrintTest.java
+++ b/mnemonic-computing-services/mnemonic-utilities-service/src/test/java/org/apache/mnemonic/service/computingservice/DurableSinglyLinkedListNGPrintTest.java
@@ -33,6 +33,7 @@ import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.collections.DurableSinglyLinkedList;
 import org.apache.mnemonic.collections.DurableSinglyLinkedListFactory;
+import org.apache.mnemonic.ParameterHolder;
 
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -80,10 +81,20 @@ public class DurableSinglyLinkedListNGPrintTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Durable create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
 
@@ -166,10 +177,24 @@ public class DurableSinglyLinkedListNGPrintTest {
         return DurableSinglyLinkedListFactory.restore(allocator, dpt.getRight(), dpt.getLeft(), phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.restore(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Durable create(A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(gfields, factoryproxys, 1);
         return DurableSinglyLinkedListFactory.create(allocator, dpt.getRight(), dpt.getLeft(), autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.create(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), ph.getAutoReclaim());
       }
     } };
 

--- a/mnemonic-computing-services/mnemonic-utilities-service/src/test/java/org/apache/mnemonic/service/computingservice/DurableSinglyLinkedListNGSortTest.java
+++ b/mnemonic-computing-services/mnemonic-utilities-service/src/test/java/org/apache/mnemonic/service/computingservice/DurableSinglyLinkedListNGSortTest.java
@@ -31,6 +31,7 @@ import org.apache.mnemonic.Durable;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.DurableType;
+import org.apache.mnemonic.ParameterHolder;
 import org.apache.mnemonic.collections.DurableSinglyLinkedList;
 import org.apache.mnemonic.collections.DurableSinglyLinkedListFactory;
 
@@ -81,10 +82,20 @@ public class DurableSinglyLinkedListNGSortTest {
         return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph) {
+        return PersonFactory.restore(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Durable create(
           A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph) {
+        return PersonFactory.create(ph.getAllocator(),
+                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
       }
     } };
 
@@ -191,10 +202,24 @@ public class DurableSinglyLinkedListNGSortTest {
         return DurableSinglyLinkedListFactory.restore(allocator, dpt.getRight(), dpt.getLeft(), phandler, autoreclaim);
       }
       @Override
+      public <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.restore(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), ph.getHandler(), ph.getAutoReclaim());
+      }
+      @Override
       public <A extends RestorableAllocator<A>> Durable create(A allocator, EntityFactoryProxy[] factoryproxys,
           DurableType[] gfields, boolean autoreclaim) {
         Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(gfields, factoryproxys, 1);
         return DurableSinglyLinkedListFactory.create(allocator, dpt.getRight(), dpt.getLeft(), autoreclaim);
+      }
+      @Override
+      public <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph) {
+        Pair<DurableType[], EntityFactoryProxy[]> dpt = Utils.shiftDurableParams(ph.getGenericTypes(),
+                ph.getEntityFactoryProxies(), 1);
+        return DurableSinglyLinkedListFactory.create(ph.getAllocator(),
+                dpt.getRight(), dpt.getLeft(), ph.getAutoReclaim());
       }
     } };
 

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/EntityFactoryProxy.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/EntityFactoryProxy.java
@@ -50,6 +50,8 @@ public interface EntityFactoryProxy {
   <A extends RestorableAllocator<A>> Durable create(A allocator, EntityFactoryProxy[] factoryproxys,
       DurableType[] gfields, boolean autoreclaim);
 
+  <A extends RestorableAllocator<A>> Durable create(ParameterHolder<A> ph);
+
   /**
    * restore a durable object from persistent allocator using a handler of
    * non-volatile object
@@ -79,4 +81,6 @@ public interface EntityFactoryProxy {
    */
   <A extends RestorableAllocator<A>> Durable restore(A allocator, EntityFactoryProxy[] factoryproxys,
       DurableType[] gfields, long phandler, boolean autoreclaim);
+
+  <A extends RestorableAllocator<A>> Durable restore(ParameterHolder<A> ph);
 }

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/ParameterHolder.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/ParameterHolder.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mnemonic;
+
+public class ParameterHolder<A extends RetrievableAllocator<A>> {
+
+    private A allocator;
+    private DurableType[] durableType;
+    private EntityFactoryProxy[] entityFactoryProxy;
+    private boolean autoReclaim;
+    private long handler;
+
+
+    public ParameterHolder() {
+        allocator = null;
+        durableType = new DurableType[]{};
+        entityFactoryProxy = null;
+        autoReclaim = true;
+        handler = 0;
+    }
+
+    public ParameterHolder(A n, DurableType[] d, EntityFactoryProxy[] e, boolean b, long h) {
+        this.allocator = n;
+        this.durableType = d;
+        this.entityFactoryProxy = e;
+        this.autoReclaim = b;
+        this.handler = h;
+    }
+
+    public void setAllocator(A n) {
+        allocator = n;
+    }
+
+    public A getAllocator() {
+        return allocator;
+    }
+
+    public void setEntityFactoryProxies(EntityFactoryProxy[] e) {
+        entityFactoryProxy = e;
+    }
+
+    public EntityFactoryProxy[] getEntityFactoryProxies() {
+        return entityFactoryProxy;
+    }
+
+    public void setAutoReclaim(boolean b) {
+        autoReclaim = b;
+    }
+
+    public boolean getAutoReclaim() {
+        return autoReclaim;
+    }
+
+    public void setGenericTypes(DurableType[] d) {
+        durableType = d;
+    }
+
+    public DurableType[] getGenericTypes() {
+        return durableType;
+    }
+
+    public void setHandler(long h) {
+        handler = h;
+    }
+
+    public long getHandler() {
+        return handler;
+    }
+}

--- a/mnemonic-hadoop/mnemonic-hadoop-mapreduce/src/test/java/org/apache/mnemonic/mapreduce/PersonListEFProxy.java
+++ b/mnemonic-hadoop/mnemonic-hadoop-mapreduce/src/test/java/org/apache/mnemonic/mapreduce/PersonListEFProxy.java
@@ -21,6 +21,7 @@ package org.apache.mnemonic.mapreduce;
 
 import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.EntityFactoryProxy;
+import org.apache.mnemonic.ParameterHolder;
 import org.apache.mnemonic.RestorableAllocator;
 
 public class PersonListEFProxy implements EntityFactoryProxy {
@@ -31,10 +32,20 @@ public class PersonListEFProxy implements EntityFactoryProxy {
     return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
   }
   @Override
+  public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+    return PersonFactory.restore(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+  }
+  @Override
   public <A extends RestorableAllocator<A>> Person<Long> create(
       A allocator, EntityFactoryProxy[] factoryproxys,
       DurableType[] gfields, boolean autoreclaim) {
     return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
+  }
+  @Override
+  public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+    return PersonFactory.create(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
   }
 
 }

--- a/mnemonic-spark/mnemonic-spark-core/src/test/java/org/apache/mnemonic/spark/PersonListEFProxy.java
+++ b/mnemonic-spark/mnemonic-spark-core/src/test/java/org/apache/mnemonic/spark/PersonListEFProxy.java
@@ -21,6 +21,7 @@ package org.apache.mnemonic.spark;
 import java.io.Serializable;
 import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.EntityFactoryProxy;
+import org.apache.mnemonic.ParameterHolder;
 import org.apache.mnemonic.RestorableAllocator;
 
 public class PersonListEFProxy  implements EntityFactoryProxy, Serializable {
@@ -31,10 +32,19 @@ public class PersonListEFProxy  implements EntityFactoryProxy, Serializable {
     return PersonFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
   }
   @Override
+  public <A extends RestorableAllocator<A>> Person<Long> restore(ParameterHolder<A> ph) {
+    return PersonFactory.restore(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
+  }
+  @Override
   public <A extends RestorableAllocator<A>> Person<Long> create(
       A allocator, EntityFactoryProxy[] factoryproxys,
       DurableType[] gfields, boolean autoreclaim) {
     return PersonFactory.create(allocator, factoryproxys, gfields, autoreclaim);
   }
-
+  @Override
+  public <A extends RestorableAllocator<A>> Person<Long> create(ParameterHolder<A> ph) {
+    return PersonFactory.create(ph.getAllocator(),
+            ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
+  }
 }


### PR DESCRIPTION
Sub-task of MNEMONIC-276. Add overloaded methods for create and restore to handle optional parameters when creating/restoring durable class. 