### PR TITLE
MNEMONIC-332: The Logo in docker page deprecated

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-<img src="http://nonvolatilecomputing.github.io/Mnemonic/images/mnemonic_logo.png" width=200 />
+<img src="https://mnemonic.incubator.apache.org/img/mnemonic_logo.png" width=200 />
 
 ================================ 
 


### PR DESCRIPTION
MNEMONIC-332: The Logo in docker page deprecated.
- Updated the logo in the docker's `README.md` to use the same in the project's `README.md`