### PR TITLE
MNEMONIC-353 Assign fixed version number to docker Centos build

### DIFF
--- a/docker/docker-CentOS/Dockerfile
+++ b/docker/docker-CentOS/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM centos:latest
+FROM centos:7
 MAINTAINER Gang Wang (garyw@apache.org)
 
 #set up your proxy below, please refer to readme in the Docker folder


### PR DESCRIPTION
Assign a version number instead of "latest" for docker Centos build for compatibility concerns.