### PR TITLE
MNEMONIC-275 Implement a default function to sync data to the persisent storage

### DIFF
--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableArrayImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableArrayImpl.java
@@ -141,7 +141,7 @@ public class DurableArrayImpl<A extends RestorableAllocator<A>, E>
    * sync. this object
    */
   @Override
-  public void sync() {
+  public void syncToVolatileMemory() {
 
   }
 
@@ -149,7 +149,7 @@ public class DurableArrayImpl<A extends RestorableAllocator<A>, E>
    * Make any cached changes to this object persistent.
    */
   @Override
-  public void persist() {
+  public void syncToNonVolatileMemory() {
 
   }
 
@@ -157,7 +157,7 @@ public class DurableArrayImpl<A extends RestorableAllocator<A>, E>
    * flush processors cache for this object
    */
   @Override
-  public void flush() {
+  public void syncToLocal() {
 
   }
 

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashMapImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashMapImpl.java
@@ -381,7 +381,7 @@ public class DurableHashMapImpl<A extends RestorableAllocator<A>, K, V>
    * sync. this object
    */
   @Override
-  public void sync() {
+  public void syncToVolatileMemory() {
 
   }
 
@@ -389,7 +389,7 @@ public class DurableHashMapImpl<A extends RestorableAllocator<A>, K, V>
    * Make any cached changes to this object persistent.
    */
   @Override
-  public void persist() {
+  public void syncToNonVolatileMemory() {
 
   }
 
@@ -397,7 +397,7 @@ public class DurableHashMapImpl<A extends RestorableAllocator<A>, K, V>
    * flush processors cache for this object
    */
   @Override
-  public void flush() {
+  public void syncToLocal() {
 
   }
 

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashSetImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashSetImpl.java
@@ -99,7 +99,7 @@ public class DurableHashSetImpl<A extends RestorableAllocator<A>, E>
    * sync. this object
    */
   @Override
-  public void sync() {
+  public void syncToVolatileMemory() {
 
   }
 
@@ -107,7 +107,7 @@ public class DurableHashSetImpl<A extends RestorableAllocator<A>, E>
    * Make any cached changes to this object persistent.
    */
   @Override
-  public void persist() {
+  public void syncToNonVolatileMemory() {
 
   }
 
@@ -115,7 +115,7 @@ public class DurableHashSetImpl<A extends RestorableAllocator<A>, E>
    * flush processors cache for this object
    */
   @Override
-  public void flush() {
+  public void syncToLocal() {
 
   }
 

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableTreeImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableTreeImpl.java
@@ -497,7 +497,7 @@ public class DurableTreeImpl<A extends RestorableAllocator<A>, E extends Compara
    * sync. this object
    */
   @Override
-  public void sync() {
+  public void syncToVolatileMemory() {
 
   }
 
@@ -505,7 +505,7 @@ public class DurableTreeImpl<A extends RestorableAllocator<A>, E extends Compara
    * Make any cached changes to this object persistent.
    */
   @Override
-  public void persist() {
+  public void syncToNonVolatileMemory() {
 
   }
 
@@ -513,7 +513,7 @@ public class DurableTreeImpl<A extends RestorableAllocator<A>, E extends Compara
    * flush processors cache for this object
    */
   @Override
-  public void flush() {
+  public void syncToLocal() {
 
   }
 

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/Allocator.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/Allocator.java
@@ -42,7 +42,7 @@ public interface Allocator<A extends CommonAllocator<A>> extends Allocatable<A> 
    *          detect the length of this memory block
    *
    */
-  void sync(long addr, long length, boolean autodetect);
+  void syncToVolatileMemory(long addr, long length, boolean autodetect);
 
   /**
    * sync. a buffer to memory.
@@ -50,7 +50,7 @@ public interface Allocator<A extends CommonAllocator<A>> extends Allocatable<A> 
    * @param mbuf
    *         specify a buffer to be sync.
    */
-  void sync(MemBufferHolder<A> mbuf);
+  void syncToVolatileMemory(MemBufferHolder<A> mbuf);
 
   /**
    * sync. a chunk to memory.
@@ -58,7 +58,7 @@ public interface Allocator<A extends CommonAllocator<A>> extends Allocatable<A> 
    * @param mchunk
    *         specify a chunk to be sync.
    */
-  void sync(MemChunkHolder<A> mchunk);
+  void syncToVolatileMemory(MemChunkHolder<A> mchunk);
 
   void syncAll();
 

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/AnnotatedDurableEntityClass.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/AnnotatedDurableEntityClass.java
@@ -189,9 +189,9 @@ public class AnnotatedDurableEntityClass {
     m_durablemtdinfo.put("getHandler", new ArrayList<MethodInfo>());
     m_durablemtdinfo.put("autoReclaim", new ArrayList<MethodInfo>());
     m_durablemtdinfo.put("destroy", new ArrayList<MethodInfo>());
-    m_durablemtdinfo.put("sync", new ArrayList<MethodInfo>());
-    m_durablemtdinfo.put("persist", new ArrayList<MethodInfo>());
-    m_durablemtdinfo.put("flush", new ArrayList<MethodInfo>());
+    m_durablemtdinfo.put("syncToVolatileMemory", new ArrayList<MethodInfo>());
+    m_durablemtdinfo.put("syncToNonVolatileMemory", new ArrayList<MethodInfo>());
+    m_durablemtdinfo.put("syncToLocal", new ArrayList<MethodInfo>());
     m_durablemtdinfo.put("getNativeFieldInfo", new ArrayList<MethodInfo>());
 
     m_entitymtdinfo.put("initializeDurableEntity", new MethodInfo());
@@ -771,14 +771,14 @@ public class AnnotatedDurableEntityClass {
           case "autoReclaim":
             code.addStatement("return $1N", autoreclaimname);
             break;
-          case "sync":
-            code.addStatement("$1N.sync()", holdername);
+          case "syncToVolatileMemory":
+            code.addStatement("$1N.syncToVolatileMemory()", holdername);
             break;
-          case "persist":
-            code.addStatement("$1N.persist()", holdername);
+          case "syncToNonVolatileMemory":
+            code.addStatement("$1N.syncToNonVolatileMemory()", holdername);
             break;
-          case "flush":
-            code.addStatement("$1N.flush()", holdername);
+          case "syncToLocal":
+            code.addStatement("$1N.syncToLocal()", holdername);
             break;
           case "destroy":
             for (String fname : m_dynfieldsinfo.keySet()) {

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/ChunkBuffer.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/ChunkBuffer.java
@@ -67,23 +67,23 @@ public class ChunkBuffer<A extends RetrievableAllocator<A>> {
     return m_dchunk;
   }
 
-  public void persist() {
+  public void syncToNonVolatileMemory() {
     if (m_dchunk.getAllocator() instanceof NonVolatileMemAllocator) {
       NonVolatileMemAllocator alloc = (NonVolatileMemAllocator) m_dchunk.getAllocator();
-      alloc.persist(m_dchunk.get() + m_offset, m_size, false);
+      alloc.syncToNonVolatileMemory(m_dchunk.get() + m_offset, m_size, false);
     } else {
       throw new UnsupportedOperationException("The ChunkBuffer does not backed by a non-volatile allocator");
       }
     }
 
-  public void sync() {
-    m_dchunk.getAllocator().sync(m_dchunk.get() + m_offset, m_size, false);
+  public void syncToVolatileMemory() {
+    m_dchunk.getAllocator().syncToVolatileMemory(m_dchunk.get() + m_offset, m_size, false);
   }
 
-  public void flush() {
+  public void syncToLocal() {
     if (m_dchunk.getAllocator() instanceof NonVolatileMemAllocator) {
       NonVolatileMemAllocator alloc = (NonVolatileMemAllocator) m_dchunk.getAllocator();
-      alloc.flush(m_dchunk.get() + m_offset, m_size, false);
+      alloc.syncToLocal(m_dchunk.get() + m_offset, m_size, false);
     } else {
       throw new UnsupportedOperationException("The ChunkBuffer does not backed by a non-volatile allocator");
     }

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/Durable.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/Durable.java
@@ -92,17 +92,17 @@ public interface Durable {
   /**
    * sync. this object
    */
-  void sync();
+  void syncToVolatileMemory();
 
   /**
    * Make any cached changes to this object persistent.
    */
-  void persist();
+  void syncToNonVolatileMemory();
 
   /**
    * flush processors cache for this object
    */
-  void flush();
+  void syncToLocal();
 
   /**
    * manually destroy this object and release its memory resource

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/DurableBuffer.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/DurableBuffer.java
@@ -57,17 +57,17 @@ public class DurableBuffer<A extends RetrievableAllocator<A>> extends MemBufferH
    * sync. this object
    */
   @Override
-  public void sync() {
-    m_allocator.sync(this);
+  public void syncToVolatileMemory() {
+    m_allocator.syncToVolatileMemory(this);
   }
 
   /**
    * Make any cached changes to this object persistent.
    */
   @Override
-  public void persist() {
+  public void syncToNonVolatileMemory() {
     if (null != m_persistOps) {
-      m_persistOps.persist(this);
+      m_persistOps.syncToNonVolatileMemory(this);
     }
   }
 
@@ -75,9 +75,9 @@ public class DurableBuffer<A extends RetrievableAllocator<A>> extends MemBufferH
    * flush processors cache for this object
    */
   @Override
-  public void flush() {
+  public void syncToLocal() {
     if (null != m_persistOps) {
-      m_persistOps.flush(this);
+      m_persistOps.syncToLocal(this);
     }
   }
 

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/DurableChunk.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/DurableChunk.java
@@ -55,17 +55,17 @@ public class DurableChunk<A extends RetrievableAllocator<A>> extends MemChunkHol
    * sync. this object
    */
   @Override
-  public void sync() {
-    m_allocator.sync(this);
+  public void syncToVolatileMemory() {
+    m_allocator.syncToVolatileMemory(this);
   }
 
   /**
    * Make any cached changes to this object persistent.
    */
   @Override
-  public void persist() {
+  public void syncToNonVolatileMemory() {
     if (null != m_persistOps) {
-      m_persistOps.persist(this);
+      m_persistOps.syncToNonVolatileMemory(this);
     }
   }
 
@@ -73,9 +73,9 @@ public class DurableChunk<A extends RetrievableAllocator<A>> extends MemChunkHol
    * flush processors cache for this object
    */
   @Override
-  public void flush() {
+  public void syncToLocal() {
     if (null != m_persistOps) {
-      m_persistOps.flush(this);
+      m_persistOps.syncToLocal(this);
     }
   }
 

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
@@ -374,51 +374,51 @@ public class GenericField<A extends RestorableAllocator<A>, E> implements Durabl
    * sync. this generic field
    */
   @Override
-  public void sync() {
+  public void syncToVolatileMemory() {
     if (null != m_allocator) {
       switch (m_dgftype) {
         case BYTE:
-          m_allocator.sync(m_fpos, Byte.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Byte.BYTES, false);
           break;
         case BOOLEAN:
-          m_allocator.sync(m_fpos, Byte.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Byte.BYTES, false);
           break;
         case CHARACTER:
-          m_allocator.sync(m_fpos, Character.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Character.BYTES, false);
           break;
         case SHORT:
-          m_allocator.sync(m_fpos, Short.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Short.BYTES, false);
           break;
         case INTEGER:
-          m_allocator.sync(m_fpos, Integer.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Integer.BYTES, false);
           break;
         case LONG:
-          m_allocator.sync(m_fpos, Long.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Long.BYTES, false);
           break;
         case FLOAT:
-          m_allocator.sync(m_fpos, Float.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Float.BYTES, false);
           break;
         case DOUBLE:
-          m_allocator.sync(m_fpos, Double.BYTES, false);
+          m_allocator.syncToVolatileMemory(m_fpos, Double.BYTES, false);
           break;
         case STRING:
           if (null != m_strfield) {
-            m_strfield.sync();
+            m_strfield.syncToVolatileMemory();
           }
           break;
         case DURABLE:
           if (null != m_field) {
-            m_field.sync();
+            m_field.syncToVolatileMemory();
           }
           break;
         case CHUNK:
           if (null != m_chunkfield) {
-            m_chunkfield.sync();
+            m_chunkfield.syncToVolatileMemory();
           }
           break;
         case BUFFER:
           if (null != m_bufferfield) {
-            m_bufferfield.sync();
+            m_bufferfield.syncToVolatileMemory();
           }
           break;
       }
@@ -429,51 +429,51 @@ public class GenericField<A extends RestorableAllocator<A>, E> implements Durabl
    * Make any cached changes to this generic field persistent.
    */
   @Override
-  public void persist() {
+  public void syncToNonVolatileMemory() {
     if (null != m_persistOps) {
       switch (m_dgftype) {
         case BYTE:
-          m_persistOps.persist(m_fpos, Byte.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Byte.BYTES, false);
           break;
         case BOOLEAN:
-          m_persistOps.persist(m_fpos, Byte.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Byte.BYTES, false);
           break;
         case CHARACTER:
-          m_persistOps.persist(m_fpos, Character.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Character.BYTES, false);
           break;
         case SHORT:
-          m_persistOps.persist(m_fpos, Short.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Short.BYTES, false);
           break;
         case INTEGER:
-          m_persistOps.persist(m_fpos, Integer.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Integer.BYTES, false);
           break;
         case LONG:
-          m_persistOps.persist(m_fpos, Long.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Long.BYTES, false);
           break;
         case FLOAT:
-          m_persistOps.persist(m_fpos, Float.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Float.BYTES, false);
           break;
         case DOUBLE:
-          m_persistOps.persist(m_fpos, Double.BYTES, false);
+          m_persistOps.syncToNonVolatileMemory(m_fpos, Double.BYTES, false);
           break;
         case STRING:
           if (null != m_strfield) {
-            m_strfield.persist();
+            m_strfield.syncToNonVolatileMemory();
           }
           break;
         case DURABLE:
           if (null != m_field) {
-            m_field.persist();
+            m_field.syncToNonVolatileMemory();
           }
           break;
         case CHUNK:
           if (null != m_chunkfield) {
-            m_chunkfield.persist();
+            m_chunkfield.syncToNonVolatileMemory();
           }
           break;
         case BUFFER:
           if (null != m_bufferfield) {
-            m_bufferfield.persist();
+            m_bufferfield.syncToNonVolatileMemory();
           }
           break;
       }
@@ -484,51 +484,51 @@ public class GenericField<A extends RestorableAllocator<A>, E> implements Durabl
    * flush processors cache for this generic field
    */
   @Override
-  public void flush() {
+  public void syncToLocal() {
     if (null != m_persistOps) {
       switch (m_dgftype) {
         case BYTE:
-          m_persistOps.flush(m_fpos, Byte.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Byte.BYTES, false);
           break;
         case BOOLEAN:
-          m_persistOps.flush(m_fpos, Byte.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Byte.BYTES, false);
           break;
         case CHARACTER:
-          m_persistOps.flush(m_fpos, Character.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Character.BYTES, false);
           break;
         case SHORT:
-          m_persistOps.flush(m_fpos, Short.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Short.BYTES, false);
           break;
         case INTEGER:
-          m_persistOps.flush(m_fpos, Integer.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Integer.BYTES, false);
           break;
         case LONG:
-          m_persistOps.flush(m_fpos, Long.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Long.BYTES, false);
           break;
         case FLOAT:
-          m_persistOps.flush(m_fpos, Float.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Float.BYTES, false);
           break;
         case DOUBLE:
-          m_persistOps.flush(m_fpos, Double.BYTES, false);
+          m_persistOps.syncToLocal(m_fpos, Double.BYTES, false);
           break;
         case STRING:
           if (null != m_strfield) {
-            m_strfield.flush();
+            m_strfield.syncToLocal();
           }
           break;
         case DURABLE:
           if (null != m_field) {
-            m_field.flush();
+            m_field.syncToLocal();
           }
           break;
         case CHUNK:
           if (null != m_chunkfield) {
-            m_chunkfield.flush();
+            m_chunkfield.syncToLocal();
           }
           break;
         case BUFFER:
           if (null != m_bufferfield) {
-            m_bufferfield.flush();
+            m_bufferfield.syncToLocal();
           }
           break;
       }

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/NonVolatileMemAllocator.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/NonVolatileMemAllocator.java
@@ -165,8 +165,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    *
    */
   @Override
-  public void sync(long addr, long length, boolean autodetect) {
-    m_nvmasvc.sync(m_nid, addr, length, autodetect);
+  public void syncToVolatileMemory(long addr, long length, boolean autodetect) {
+    m_nvmasvc.syncToVolatileMemory(m_nid, addr, length, autodetect);
   }
 
   /**
@@ -413,8 +413,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    *         specify a buffer to be sync.
    */
   @Override
-  public void sync(MemBufferHolder<NonVolatileMemAllocator> mbuf) {
-    m_nvmasvc.sync(m_nid, getBufferAddress(mbuf), 0L, true);
+  public void syncToVolatileMemory(MemBufferHolder<NonVolatileMemAllocator> mbuf) {
+    m_nvmasvc.syncToVolatileMemory(m_nid, getBufferAddress(mbuf), 0L, true);
   }
 
   /**
@@ -424,8 +424,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    *         specify a chunk to be sync.
    */
   @Override
-  public void sync(MemChunkHolder<NonVolatileMemAllocator> mchunk) {
-    m_nvmasvc.sync(m_nid, getChunkAddress(mchunk), 0L, true);
+  public void syncToVolatileMemory(MemChunkHolder<NonVolatileMemAllocator> mchunk) {
+    m_nvmasvc.syncToVolatileMemory(m_nid, getChunkAddress(mchunk), 0L, true);
   }
 
   /**
@@ -433,7 +433,7 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    */
   @Override
   public void syncAll() {
-    m_nvmasvc.sync(m_nid, 0L, 0L, true);
+    m_nvmasvc.syncToVolatileMemory(m_nid, 0L, 0L, true);
   }
 
   /**
@@ -444,8 +444,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    * @param autodetect if NULL == address and autodetect : persist whole pool
    */
   @Override
-  public void persist(long addr, long length, boolean autodetect) {
-    m_nvmasvc.persist(m_nid, addr, length, autodetect);
+  public void syncToNonVolatileMemory(long addr, long length, boolean autodetect) {
+    m_nvmasvc.syncToNonVolatileMemory(m_nid, addr, length, autodetect);
   }
 
   /**
@@ -456,8 +456,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    * @param autodetect if NULL == address and autodetect : flush whole pool
    */
   @Override
-  public void flush(long addr, long length, boolean autodetect) {
-    m_nvmasvc.flush(m_nid, addr, length, autodetect);
+  public void syncToLocal(long addr, long length, boolean autodetect) {
+    m_nvmasvc.syncToLocal(m_nid, addr, length, autodetect);
   }
 
   /**
@@ -467,8 +467,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    *         specify a buffer to be persisted
    */
   @Override
-  public void persist(MemBufferHolder<NonVolatileMemAllocator> mbuf) {
-    m_nvmasvc.persist(m_nid, getBufferAddress(mbuf), 0L, true);
+  public void syncToNonVolatileMemory(MemBufferHolder<NonVolatileMemAllocator> mbuf) {
+    m_nvmasvc.syncToNonVolatileMemory(m_nid, getBufferAddress(mbuf), 0L, true);
   }
 
   /**
@@ -478,8 +478,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    *         specify a chunk to be persisted
    */
   @Override
-  public void persist(MemChunkHolder<NonVolatileMemAllocator> mchunk) {
-    m_nvmasvc.persist(m_nid, getChunkAddress(mchunk), 0L, true);
+  public void syncToNonVolatileMemory(MemChunkHolder<NonVolatileMemAllocator> mchunk) {
+    m_nvmasvc.syncToNonVolatileMemory(m_nid, getChunkAddress(mchunk), 0L, true);
   }
 
   /**
@@ -487,7 +487,7 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    */
   @Override
   public void persistAll() {
-    m_nvmasvc.persist(m_nid, 0L, 0L, true);
+    m_nvmasvc.syncToNonVolatileMemory(m_nid, 0L, 0L, true);
   }
 
   /**
@@ -497,8 +497,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    *         specify a buffer to be flushed
    */
   @Override
-  public void flush(MemBufferHolder<NonVolatileMemAllocator> mbuf) {
-    m_nvmasvc.flush(m_nid, getBufferAddress(mbuf), 0L, true);
+  public void syncToLocal(MemBufferHolder<NonVolatileMemAllocator> mbuf) {
+    m_nvmasvc.syncToLocal(m_nid, getBufferAddress(mbuf), 0L, true);
   }
 
   /**
@@ -508,8 +508,8 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    *         specify a chunk to be flushed
    */
   @Override
-  public void flush(MemChunkHolder<NonVolatileMemAllocator> mchunk) {
-    m_nvmasvc.flush(m_nid, getChunkAddress(mchunk), 0L, true);
+  public void syncToLocal(MemChunkHolder<NonVolatileMemAllocator> mchunk) {
+    m_nvmasvc.syncToLocal(m_nid, getChunkAddress(mchunk), 0L, true);
   }
 
   /**
@@ -517,7 +517,7 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
    */
   @Override
   public void flushAll() {
-    m_nvmasvc.flush(m_nid, 0L, 0L, true);
+    m_nvmasvc.syncToLocal(m_nid, 0L, 0L, true);
   }
 
   /**
@@ -720,7 +720,7 @@ public class NonVolatileMemAllocator extends RestorableAllocator<NonVolatileMemA
 
   /**
    * Get a queryable object
-   *
+   *f
    * @return a queryable object
    */
   Queryable useQuery() {

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/Persistence.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/Persistence.java
@@ -34,7 +34,7 @@ public interface Persistence<A extends RetrievableAllocator<A>> {
      *          if NULL == address and autodetect : persist whole pool
      *          if 0L == length and autodetect : persist block
      */
-    void persist(long addr, long length, boolean autodetect);
+    void syncToNonVolatileMemory(long addr, long length, boolean autodetect);
 
     /**
      * flush processors cache for a memory resource
@@ -49,7 +49,7 @@ public interface Persistence<A extends RetrievableAllocator<A>> {
      *          if NULL == address and autodetect : flush whole pool
      *          if 0L == length and autodetect : flush block
      */
-    void flush(long addr, long length, boolean autodetect);
+    void syncToLocal(long addr, long length, boolean autodetect);
 
     /**
      * persist a buffer to persistent memory.
@@ -57,7 +57,7 @@ public interface Persistence<A extends RetrievableAllocator<A>> {
      * @param mbuf
      *         specify a buffer to be persisted
      */
-    void persist(MemBufferHolder<A> mbuf);
+    void syncToNonVolatileMemory(MemBufferHolder<A> mbuf);
 
     /**
      * persist a chunk to persistent memory.
@@ -65,7 +65,7 @@ public interface Persistence<A extends RetrievableAllocator<A>> {
      * @param mchunk
      *         specify a chunk to be persisted
      */
-    void persist(MemChunkHolder<A> mchunk);
+    void syncToNonVolatileMemory(MemChunkHolder<A> mchunk);
 
     /**
      * persist the memory pool to persistent memory.
@@ -78,7 +78,7 @@ public interface Persistence<A extends RetrievableAllocator<A>> {
      * @param mbuf
      *         specify a buffer to be flushed
      */
-    void flush(MemBufferHolder<A> mbuf);
+    void syncToLocal(MemBufferHolder<A> mbuf);
 
     /**
      * flush a chunk to persistent memory.
@@ -86,7 +86,7 @@ public interface Persistence<A extends RetrievableAllocator<A>> {
      * @param mchunk
      *         specify a chunk to be flushed
      */
-    void flush(MemChunkHolder<A> mchunk);
+    void syncToLocal(MemChunkHolder<A> mchunk);
 
     /**
      * flush the memory pool to persistent memory.

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/SysMemAllocator.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/SysMemAllocator.java
@@ -169,7 +169,7 @@ public class SysMemAllocator extends CommonAllocator<SysMemAllocator> {
    *
    */
   @Override
-  public void sync(long addr, long length, boolean autodetect) {
+  public void syncToVolatileMemory(long addr, long length, boolean autodetect) {
     throw new UnsupportedOperationException("SysMemAllocator doesn't support sync");
   }
 
@@ -179,7 +179,7 @@ public class SysMemAllocator extends CommonAllocator<SysMemAllocator> {
    * @param mbuf specify a buffer to be sync.
    */
   @Override
-  public void sync(MemBufferHolder<SysMemAllocator> mbuf) {
+  public void syncToVolatileMemory(MemBufferHolder<SysMemAllocator> mbuf) {
     throw new UnsupportedOperationException("SysMemAllocator doesn't support sync");
   }
 
@@ -189,7 +189,7 @@ public class SysMemAllocator extends CommonAllocator<SysMemAllocator> {
    * @param mchunk specify a chunk to be sync.
    */
   @Override
-  public void sync(MemChunkHolder<SysMemAllocator> mchunk) {
+  public void syncToVolatileMemory(MemChunkHolder<SysMemAllocator> mchunk) {
     throw new UnsupportedOperationException("SysMemAllocator doesn't support sync");
   }
 

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/VolatileMemAllocator.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/VolatileMemAllocator.java
@@ -187,8 +187,8 @@ public class VolatileMemAllocator extends RestorableAllocator<VolatileMemAllocat
    *
    */
   @Override
-  public void sync(long addr, long length, boolean autodetect) {
-    m_vmasvc.sync(m_nid, addr, length, autodetect);
+  public void syncToVolatileMemory(long addr, long length, boolean autodetect) {
+    m_vmasvc.syncToVolatileMemory(m_nid, addr, length, autodetect);
   }
 
   /**
@@ -431,8 +431,8 @@ public class VolatileMemAllocator extends RestorableAllocator<VolatileMemAllocat
    *         specify a buffer to be sync.
    */
   @Override
-  public void sync(MemBufferHolder<VolatileMemAllocator> mbuf) {
-    m_vmasvc.sync(m_nid, getBufferAddress(mbuf), 0L, true);
+  public void syncToVolatileMemory(MemBufferHolder<VolatileMemAllocator> mbuf) {
+    m_vmasvc.syncToVolatileMemory(m_nid, getBufferAddress(mbuf), 0L, true);
   }
 
   /**
@@ -442,8 +442,8 @@ public class VolatileMemAllocator extends RestorableAllocator<VolatileMemAllocat
    *         specify a chunk to be sync.
    */
   @Override
-  public void sync(MemChunkHolder<VolatileMemAllocator> mchunk) {
-    m_vmasvc.sync(m_nid, getChunkAddress(mchunk), 0L, true);
+  public void syncToVolatileMemory(MemChunkHolder<VolatileMemAllocator> mchunk) {
+    m_vmasvc.syncToVolatileMemory(m_nid, getChunkAddress(mchunk), 0L, true);
   }
 
   /**
@@ -451,7 +451,7 @@ public class VolatileMemAllocator extends RestorableAllocator<VolatileMemAllocat
    */
   @Override
   public void syncAll() {
-    m_vmasvc.sync(m_nid, 0L, 0L, true);
+    m_vmasvc.syncToVolatileMemory(m_nid, 0L, 0L, true);
   }
 
   /**

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/service/memory/NonVolatileMemoryAllocatorService.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/service/memory/NonVolatileMemoryAllocatorService.java
@@ -116,7 +116,7 @@ public interface NonVolatileMemoryAllocatorService extends VolatileMemoryAllocat
    *          if NULL == address and autodetect : persist whole pool
    *          if 0L == length and autodetect : persist block
    */
-  void persist(long id, long addr, long length, boolean autodetect);
+  void syncToNonVolatileMemory(long id, long addr, long length, boolean autodetect);
 
   /**
    * flush processors cache for a memory resource
@@ -134,7 +134,7 @@ public interface NonVolatileMemoryAllocatorService extends VolatileMemoryAllocat
    *          if NULL == address and autodetect : flush whole pool
    *          if 0L == length and autodetect : flush block
    */
-  void flush(long id, long addr, long length, boolean autodetect);
+  void syncToLocal(long id, long addr, long length, boolean autodetect);
 
   /**
    * wait for any memory resource stores to drain from HW buffers.

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/service/memory/VolatileMemoryAllocatorService.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/service/memory/VolatileMemoryAllocatorService.java
@@ -174,7 +174,7 @@ public interface VolatileMemoryAllocatorService extends QueryableService {
    *          if NULL == address and autodetect : sync. whole pool
    *          if 0L == length and autodetect : sync. block
    */
-  void sync(long id, long addr, long length, boolean autodetect);
+  void syncToVolatileMemory(long id, long addr, long length, boolean autodetect);
 
   /**
    * get the capacity of its managed memory space

--- a/mnemonic-memory-services/mnemonic-java-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/JavaVMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-java-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/JavaVMemServiceImpl.java
@@ -156,7 +156,7 @@ public class JavaVMemServiceImpl implements VolatileMemoryAllocatorService {
   }
 
   @Override
-  public void sync(long id, long addr, long length, boolean autodetect) {
+  public void syncToVolatileMemory(long id, long addr, long length, boolean autodetect) {
     throw new UnsupportedOperationException("Unsupported to synchronization operation");
   }
 

--- a/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMemServiceImpl.java
@@ -59,7 +59,7 @@ public class PMemServiceImpl implements NonVolatileMemoryAllocatorService {
   }
 
   @Override
-  public void sync(long id, long addr, long length, boolean autodetect) {
+  public void syncToVolatileMemory(long id, long addr, long length, boolean autodetect) {
     nsync(id, addr, length, autodetect);
   }
 
@@ -129,12 +129,12 @@ public class PMemServiceImpl implements NonVolatileMemoryAllocatorService {
   }
 
   @Override
-  public void persist(long id, long addr, long length, boolean autodetect) {
+  public void syncToNonVolatileMemory(long id, long addr, long length, boolean autodetect) {
     npersist(id, addr, length, autodetect);
   }
 
   @Override
-  public void flush(long id, long addr, long length, boolean autodetect) {
+  public void syncToLocal(long id, long addr, long length, boolean autodetect) {
     nflush(id, addr, length, autodetect);
   }
 

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/VMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/VMemServiceImpl.java
@@ -66,7 +66,7 @@ public class VMemServiceImpl implements VolatileMemoryAllocatorService {
   }
 
   @Override
-  public void sync(long id, long addr, long length, boolean autodetect) {
+  public void syncToVolatileMemory(long id, long addr, long length, boolean autodetect) {
     nsync(id, addr, length, autodetect);
   }
 

--- a/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMallocServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMallocServiceImpl.java
@@ -59,7 +59,7 @@ public class PMallocServiceImpl implements NonVolatileMemoryAllocatorService {
   }
 
   @Override
-  public void sync(long id, long addr, long length, boolean autodetect) {
+  public void syncToVolatileMemory(long id, long addr, long length, boolean autodetect) {
     nsync(id, addr, length, autodetect);
   }
 
@@ -129,12 +129,12 @@ public class PMallocServiceImpl implements NonVolatileMemoryAllocatorService {
   }
 
   @Override
-  public void persist(long id, long addr, long length, boolean autodetect) {
+  public void syncToNonVolatileMemory(long id, long addr, long length, boolean autodetect) {
     npersist(id, addr, length, autodetect);
   }
 
   @Override
-  public void flush(long id, long addr, long length, boolean autodetect) {
+  public void syncToLocal(long id, long addr, long length, boolean autodetect) {
     nflush(id, addr, length, autodetect);
   }
 

--- a/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/SysVMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/SysVMemServiceImpl.java
@@ -66,7 +66,7 @@ public class SysVMemServiceImpl implements VolatileMemoryAllocatorService {
   }
 
   @Override
-  public void sync(long id, long addr, long length, boolean autodetect) {
+  public void syncToVolatileMemory(long id, long addr, long length, boolean autodetect) {
     nsync(id, addr, length, autodetect);
   }
 


### PR DESCRIPTION
Currently persist(), sync(), flush() calls are exposed to the user. This is confusing.  Only one call should be exposed to user that provides the default functionality. 